### PR TITLE
UI/UX improvements for trade history view/edit/delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,23 @@
 - Trade dashboard with P&L tracking
 - Excel export with filters
 - Resource pinning and last accessed tracking
+- Seperate Completed Trades page
 - Secure config via environment variables
+- Watchlist page
+- Trades history Page
+- Notes page 
+- Simple statistics for our trading performance tracking
+
+## [v1.1.0] - 2025-09-30
+### Added
+- View button in `trade_history.html` with consistent styling
+- Unified button layout for Apply / Export / Print
+- Reuse of dashboard delete route for completed trades
+
+### Changed
+- `trade_history()` now includes `trade.id` for action buttons
+- Redirect after delete now respects `request.referrer`
+
+### Fixed
+- Button size inconsistencies between view and delete
+- Internal server error from missing `id` in enriched dictionary

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A secure, modular trading journal built with Flask. Track trades, pin resources,
 - 🕒 Trades history Page
 - 🕒 Notes page 
 - 🕒 Simple statistics for our trading performance tracking
+- 🖥️ Enhanced trade history view with action buttons (v1.1)
 
 ## 🚀 Getting Started Steps
 
@@ -24,3 +25,14 @@ pip install -r requirements.txt
 flask run
 ```
 Make sure to add secrets to your .env file.
+.env file format as below.
+
+```bash
+SECRET_KEY=<your secret key here>
+DATABASE_URL=<postgresql://username:password@localhost/db_name>
+SQLALCHEMY_TRACK_MODIFICATIONS=False
+SQLALCHEMY_ECHO=False
+FLASK_ENV=<production / dev >
+REMEMBER_COOKIE_SECURE=< True / False >
+SESSION_COOKIE_SECURE=< True / False >
+```

--- a/app/routes/trades.py
+++ b/app/routes/trades.py
@@ -386,7 +386,9 @@ def delete_trade(trade_id):
         db.session.rollback()
         flash(f"Error deleting trade: {str(e)}", "error")
 
-    return redirect(url_for('trades.dashboard'))
+    return redirect(request.referrer or url_for('trades.dashboard'))
+
+    # return redirect(url_for('trades.dashboard'))
 
 #trade_history() Route
 @trades_bp.route('/history', methods=['GET'])
@@ -434,6 +436,7 @@ def trade_history():
         combined_notes = " | ".join(entry_notes + exit_notes)
 
         enriched.append({
+            'id': trade.id,  # ✅ Add this line to fetch trade.id in view button
             'stock_name': trade.stock_name.upper(),
             'entry_date': trade.entry_date,
             'exit_date': trade.exit_date,

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -51,30 +51,30 @@
               <span style="color:gray;">—</span>
             {% endif %}
           </td>
-<td style="white-space: nowrap;">
-  <div style="display: inline-flex; gap: 6px; align-items: center;">
-    <a href="{{ url_for('trades.view_trade', trade_id=trade.id) }}"
-       class="btn btn-sm btn-outline-secondary" title="View">
-      🔍
-    </a>
+          <td style="white-space: nowrap;">
+            <div style="display: inline-flex; gap: 6px; align-items: center;">
+              <a href="{{ url_for('trades.view_trade', trade_id=trade.id) }}"
+                class="btn btn-sm btn-outline-secondary" title="View" style="padding: 4px 8px; font-size: 0.875rem; line-height: 1.2;">
+                🔍
+              </a>
 
-    <a href="{{ url_for('trades.edit_trade', trade_id=trade.id) }}"
-       class="btn btn-sm btn-outline-primary" title="Edit">
-      ✏️
-    </a>
+              <a href="{{ url_for('trades.edit_trade', trade_id=trade.id) }}"
+                class="btn btn-sm btn-outline-primary" title="Edit" style="padding: 4px 8px; font-size: 0.875rem; line-height: 1.2;">
+                ✏️
+              </a>
 
-    <form method="POST" action="{{ url_for('trades.delete_trade', trade_id=trade.id) }}" style="margin:0;">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <button type="submit"
-              class="btn btn-sm btn-outline-danger"
-              onclick="return confirm('Delete this trade?')"
-              title="Delete">
-        🗑️
-      </button>
-    </form>
-  </div>
-</td>
-
+              <form method="POST" action="{{ url_for('trades.delete_trade', trade_id=trade.id) }}" style="margin:0;">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit"
+                        class="btn btn-sm btn-outline-danger"
+                        onclick="return confirm('Delete this trade?')"
+                        title="Delete"
+                        style="background-color:#bd5656; padding: 4px 8px; font-size: 0.875rem; line-height: 1.2;">
+                  🗑️
+                </button>
+              </form>
+            </div>
+          </td>
 
         </tr>
       {% endfor %}

--- a/app/templates/resources.html
+++ b/app/templates/resources.html
@@ -45,12 +45,13 @@
       <td>{{ r.category }}</td>
       <td>{{ r.note }}</td>
       <td>{{ '📌' if r.pinned else '' }}</td>
-      <td>{{ r.last_accessed.strftime('%d-%m-%Y %H:%M') if r.last_accessed else '—' }}</td>
+      <td>{{ r.last_accessed.strftime('%d-%m-%Y') if r.last_accessed else '—' }}</td> <!-- date format - '%d-%m-%Y %H:%M'-->
         <td style="white-space: nowrap;">
           <div style="display: inline-flex; gap: 6px; align-items: center;">
             <button type="button"
                     class="btn btn-sm btn-outline-primary"
-                    onclick="openEditModal({{ r.id }}, '{{ r.title }}', '{{ r.url }}', '{{ r.category }}', `{{ r.note|escape }}`, {{ 'true' if r.pinned else 'false' }})">
+                    onclick="openEditModal({{ r.id }}, '{{ r.title }}', '{{ r.url }}', '{{ r.category }}', `{{ r.note|escape }}`, {{ 'true' if r.pinned else 'false' }})"
+                    style="background-color:#0172ad; color:white; padding:4px 10px; border-radius:4px; text-decoration:none; margin-right:4px;">
               ✏️
             </button>
 
@@ -58,7 +59,8 @@
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button type="submit"
                       class="btn btn-sm btn-outline-danger"
-                      onclick="return confirm('Delete this resource?')">
+                      onclick="return confirm('Delete this resource?')"
+                      style="background-color:#bd5656; color:white; padding:4px 10px; border-radius:4px; text-decoration:none; margin-right:4px;">
                 🗑️
               </button>
             </form>

--- a/app/templates/trade_history.html
+++ b/app/templates/trade_history.html
@@ -35,14 +35,14 @@
       </select>
     </div>
 
-    <div style="display:flex; gap:5px; margin-top:1.5em;">
-      <button type="submit" title="Apply selected filters">🔍 Apply</button>
+    <div style="display: inline-flex; gap: 10px; margin-top: 1.5em; align-items: center;">
+      <button type="submit" title="Apply selected filters" style="padding: 6px 16px; font-size: 0.9rem; background-color: #007bff; color: white; border: none; border-radius: 4px; cursor: pointer;">🔍 Apply</button>
       <a href="{{ url_for('trades.export_history', stock=selected_stock, date_range=selected_range, sort=sort) }}"
          class="button" title="Download filtered trades as Excel"
-         style="text-decoration:none; padding:4px 22px; background:#007bff; color:white; border-radius:4px;">📤 Export</a>
-           <button onclick="window.print()" class="button" style="background:#6c757d; color:white;">
-            🖨️ Print / Save as PDF
-      </button>
+         style="padding: 6px 16px; font-size: 0.9rem; background-color: #17a2b8; color: white; border-radius: 4px; text-decoration: none; display: inline-block;">📤 Export</a>
+           <button onclick="window.print()" title="Print or Save as PDF" class="button" style="padding: 6px 16px; font-size: 0.9rem; background-color: #6c757d; color: white; border: none; border-radius: 4px; cursor: pointer;">
+            🖨️ Print PDF
+      </button> <!-- style="display: inline-flex; gap: 6px; align-items: center;" text-decoration:none; background:#6c757d; color:white; -->
     </div>
 
   </div>
@@ -64,6 +64,7 @@
           <th>Duration</th>
           <th>Realized P&L</th>
           <th>Notes</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -84,6 +85,37 @@
               {% endif %}
             </td>
             <td>{{ t.notes or '—' }}</td>
+            <td style="white-space: nowrap;">
+              <div style="display: inline-flex; gap: 6px; align-items: center;">
+                <!-- View -->
+                <form method="GET" action="{{ url_for('trades.view_trade', trade_id=t['id']) }}" style="margin:0;">
+                  <button type="submit"
+                          class="btn btn-sm btn-outline-info"
+                          title="View Trade"
+                          style="padding: 4px 8px;">
+                    🔍
+                  </button>
+                </form>
+
+                <!-- Edit disabled on history page -->
+                <!-- <a href="{{ url_for('trades.edit_trade', trade_id=t['id']) }}"
+                  class="btn btn-sm btn-outline-primary" title="Edit">
+                  ✏️
+                </a> -->
+
+                <!-- Delete -->
+                <form method="POST" action="{{ url_for('trades.delete_trade', trade_id=t['id']) }}" style="margin:0;">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <button type="submit"
+                          class="btn btn-sm btn-outline-danger"
+                          onclick="return confirm('Delete this trade?')"
+                          title="Delete"
+                          style="background-color:#bd5656; padding: 4px 8px; font-size: 0.875rem; line-height: 1.2;">
+                    🗑️
+                  </button>
+                </form>
+              </div>
+            </td>
           </tr>
         {% endfor %}
       </tbody>

--- a/app/templates/view_trade.html
+++ b/app/templates/view_trade.html
@@ -98,16 +98,13 @@
               style="background-color:#007bff; color:white; padding:4px 10px; border-radius:4px; text-decoration:none; margin-right:4px;">
               ✏️ Edit
             </a>
-
             <button type="button"
                     onclick="openModal('entry-{{ e.id }}')"
                     style="background-color:#dc3545; color:white; padding:4px 10px; border-radius:4px; border:none;">
               🗑️ Delete
             </button>
           </td>
-
         </tr>
-
 
       {% endfor %}
     </tbody>
@@ -138,7 +135,7 @@
 
             <button type="button"
                     onclick="openModal('exit-{{ x.id }}')"
-                    style="background-color:#dc3545; color:white; padding:4px 10px; border-radius:4px; border:none;">
+                    style="background-color:#bd5656; color:white; padding:4px 10px; border-radius:4px; border:none;  margin-right:4px;">
               🗑️ Delete
             </button>
           </td>
@@ -187,6 +184,5 @@ function closeModal() {
   document.getElementById('modal-overlay').style.display = 'none';
 }
 </script>
-
 
 {% endblock %}

--- a/app/templates/watchlist.html
+++ b/app/templates/watchlist.html
@@ -104,12 +104,25 @@
         <a href="{{ url_for('watchlist.edit', item_id=item.id) }}" class="btn btn-sm btn-primary">✏️ Edit</a>
         <a href="{{ url_for('watchlist.delete', item_id=item.id) }}" class="btn btn-sm btn-danger">🗑️ Delete</a>
       </td> -->
-      <td>
-        <a href="{{ url_for('watchlist.edit', item_id=item.id) }}" class="btn btn-sm btn-primary">✏️ Edit</a>
+      <td style="white-space: nowrap;">
+        <div style="display: inline-flex; gap: 6px; align-items: center;">
+        <!-- <a href="{{ url_for('watchlist.edit', item_id=item.id) }}" class="btn btn-sm btn-primary">✏️ Edit</a> -->
+                <form method="GET" action="{{ url_for('watchlist.edit', item_id=item.id) }}" style="margin:0;">
+                  <button type="submit"
+                          class="btn btn-sm btn-outline-info"
+                          title="View Trade"
+                          style="padding: 4px 8px;">
+                    ✏️
+                  </button>
+                </form>
+
+
         <form method="POST" action="{{ url_for('watchlist.delete', item_id=item.id) }}" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this item?');">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="btn btn-sm btn-danger">🗑️ Delete</button>
+            <button type="submit" class="btn btn-sm btn-danger" style="background-color:#bd5656; padding: 4px 8px; font-size: 0.875rem; line-height: 1.2;">
+              🗑️ </button>
         </form>
+      </div>
       </td>
     </tr>
     {% else %}


### PR DESCRIPTION
### Added
- View button in `trade_history.html` with consistent styling
- Unified button layout for Apply / Export / Print
- Reuse of dashboard delete route for completed trades

### Changed
- `trade_history()` now includes `trade.id` for action buttons
- Redirect after delete now respects `request.referrer`

### Fixed
- Button size inconsistencies between view and delete
- Internal server error from missing `id` in enriched dictionary
